### PR TITLE
Only use ipv4 addresses for `__meta_pve_ip`

### DIFF
--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -3,7 +3,7 @@
 
 import json
 import re
-import socket
+import ipaddress
 from collections import defaultdict
 
 import requests
@@ -89,12 +89,9 @@ class Discovery():
 
         def validate_ipv4(address: object) -> object:
             try:
-                # IP address validation
-                if socket.inet_aton(address):
-                    # Ignore localhost
-                    if address != "127.0.0.1":
-                        return address
-            except socket.error:
+                if ipaddress.ip_address(address) not in ipaddress.ip_network("127.0.0.0/8"):
+                    return address
+            except ValueError:
                 return False
 
         address = False

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -87,7 +87,7 @@ class Discovery():
 
     def _get_ip_address(self, pve_type, pve_node, vmid):
 
-        def validate(address):
+        def validate_ipv4(address: object) -> object:
             try:
                 # IP address validation
                 if socket.inet_aton(address):
@@ -114,7 +114,8 @@ class Discovery():
                 if type(networks) is list:
                     for network in networks:
                         for ip_address in network["ip-addresses"]:
-                            address = validate(ip_address["ip-address"])
+                            if ip_address['ip-address-type'] == 'ipv4':
+                                address = validate_ipv4(ip_address["ip-address"])
 
         if not address:
             try:

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Prometheus Discovery."""
 
+import ipaddress
 import json
 import re
-import ipaddress
 from collections import defaultdict
 
 import requests

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -111,7 +111,7 @@ class Discovery():
                 if type(networks) is list:
                     for network in networks:
                         for ip_address in network["ip-addresses"]:
-                            if ip_address['ip-address-type'] == 'ipv4':
+                            if ip_address["ip-address-type"] == "ipv4":
                                 address = validate_ipv4(ip_address["ip-address"])
 
         if not address:


### PR DESCRIPTION
This PR skips all ipv6 addresses on the interfaces, and only tries to validate ipv4 addresses.
To make the code more obvious it also renamed `validate` to `validate_ipv4`

Improves on #148 