### PR TITLE
Ensure vmid exclude compares the same datatypes

### DIFF
--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -142,7 +142,7 @@ class Discovery():
             if obj["status"] in map(str, self.config.config["exclude_state"]):
                 continue
 
-            if obj["vmid"] in map(str, self.config.config["exclude_vmid"]):
+            if str(obj["vmid"]) in self.config.config["exclude_vmid"]:
                 continue
 
             filtered.append(item.copy())


### PR DESCRIPTION
Fixes #151 

Proxmox (atlest in version7) returns vmid as int, this change ensures that it is compared as a string.
Instead of using the map, it's also possible to just use the `in` comparison, since the configuration currently enforces `exclude_vmid` to be a list of strings