### PR TITLE
ipv6 support

### DIFF
--- a/docs/content/configuration/defaults.md
+++ b/docs/content/configuration/defaults.md
@@ -25,6 +25,7 @@ loop_delay: 300
 service: true
 
 exclude_state: []
+# needs to be a list of strings
 exclude_vmid: []
 
 pve:

--- a/docs/content/configuration/defaults.md
+++ b/docs/content/configuration/defaults.md
@@ -24,9 +24,6 @@ loop_delay: 300
 # Can be disabled to run disovery only once.
 service: true
 
-# By default ipv4 addresses are preferred
-prefer_ipv6: false
-
 exclude_state: []
 exclude_vmid: []
 

--- a/docs/content/configuration/defaults.md
+++ b/docs/content/configuration/defaults.md
@@ -24,6 +24,9 @@ loop_delay: 300
 # Can be disabled to run disovery only once.
 service: true
 
+# By default ipv4 addresses are preferred
+prefer_ipv6: false
+
 exclude_state: []
 exclude_vmid: []
 

--- a/docs/content/usage/_index.md
+++ b/docs/content/usage/_index.md
@@ -16,7 +16,9 @@ run prometheus-pve-sd -vv --loop-delay 900 -o /etc/prometheus/pve.json
 
 The following list of meta labels can be used to relabel your scrape results:
 
-`__meta_pve_ip`
+`__meta_pve_ipv4`
+
+`__meta_pve_ipv6`
 
 `__meta_pve_name`
 

--- a/prometheuspvesd/config.py
+++ b/prometheuspvesd/config.py
@@ -82,6 +82,12 @@ class Config():
             "file": True,
             "type": environs.Env().bool
         },
+        "prefer_ipv6": {
+            "default": False,
+            "env": "PREFER_IPV6",
+            "file": True,
+            "type": environs.Env().bool
+        },
         "exclude_state": {
             "default": [],
             "env": "EXCLUDE_STATE",

--- a/prometheuspvesd/config.py
+++ b/prometheuspvesd/config.py
@@ -82,12 +82,6 @@ class Config():
             "file": True,
             "type": environs.Env().bool
         },
-        "prefer_ipv6": {
-            "default": False,
-            "env": "PREFER_IPV6",
-            "file": True,
-            "type": environs.Env().bool
-        },
         "exclude_state": {
             "default": [],
             "env": "EXCLUDE_STATE",

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -3,7 +3,7 @@
 
 import json
 import re
-import socket
+import ipaddress
 from collections import defaultdict
 
 import requests
@@ -89,12 +89,9 @@ class Discovery():
 
         def validate_ipv4(address: object) -> object:
             try:
-                # IP address validation
-                if socket.inet_aton(address):
-                    # Ignore localhost
-                    if address != "127.0.0.1":
-                        return address
-            except socket.error:
+                if ipaddress.ip_address(address) not in ipaddress.ip_network("127.0.0.0/8"):
+                    return address
+            except ValueError:
                 return False
 
         address = False

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -94,6 +94,13 @@ class Discovery():
             except ValueError:
                 return False
 
+        def validate_ipv6(address: object) -> object:
+            try:
+                if ipaddress.ip_address(address) not in ipaddress.ip_network("::1/128"):
+                    return address
+            except ValueError:
+                return False
+
         address = False
         networks = False
         if pve_type == "qemu":
@@ -113,6 +120,9 @@ class Discovery():
                         for ip_address in network["ip-addresses"]:
                             if ip_address["ip-address-type"] == "ipv4":
                                 address = validate_ipv4(ip_address["ip-address"])
+                            elif ip_address["ip-address-type"] == "ipv6" \
+                                    and self.config.config["prefer_ipv6"]:
+                                address = validate_ipv6(ip_address["ip-address"])
 
         if not address:
             try:

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -87,7 +87,7 @@ class Discovery():
 
     def _get_ip_address(self, pve_type, pve_node, vmid):
 
-        def validate(address):
+        def validate_ipv4(address: object) -> object:
             try:
                 # IP address validation
                 if socket.inet_aton(address):
@@ -114,7 +114,8 @@ class Discovery():
                 if type(networks) is list:
                     for network in networks:
                         for ip_address in network["ip-addresses"]:
-                            address = validate(ip_address["ip-address"])
+                            if ip_address['ip-address-type'] == 'ipv4':
+                                address = validate_ipv4(ip_address["ip-address"])
 
         if not address:
             try:

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Prometheus Discovery."""
 
+import ipaddress
 import json
 import re
-import ipaddress
 from collections import defaultdict
 
 import requests

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -111,7 +111,7 @@ class Discovery():
                 if type(networks) is list:
                     for network in networks:
                         for ip_address in network["ip-addresses"]:
-                            if ip_address['ip-address-type'] == 'ipv4':
+                            if ip_address["ip-address-type"] == "ipv4":
                                 address = validate_ipv4(ip_address["ip-address"])
 
         if not address:

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -87,18 +87,10 @@ class Discovery():
 
     def _get_ip_addresses(self, pve_type, pve_node, vmid):
 
-        def validate_ipv4(address: object) -> object:
+        def validate_ip(address: object) -> object:
             try:
-                if ipaddress.ip_address(address) not in ipaddress.ip_network("127.0.0.0/8"):
-                    return address
-            except ValueError:
-                return False
-
-        def validate_ipv6(address: object) -> object:
-            try:
-                # Make sure to skip loopback addresses and local-link addresses
-                if ipaddress.ip_address(address) not in ipaddress.ip_network("::1/128") \
-                        and ipaddress.ip_address(address) not in ipaddress.ip_network("fe80::/10"):
+                if not ipaddress.ip_address(address).is_loopback \
+                        and not ipaddress.ip_address(address).is_link_local:
                     return address
             except ValueError:
                 return False
@@ -122,9 +114,9 @@ class Discovery():
                     for network in networks:
                         for ip_address in network["ip-addresses"]:
                             if ip_address["ip-address-type"] == "ipv4":
-                                ipv4_address = validate_ipv4(ip_address["ip-address"])
+                                ipv4_address = validate_ip(ip_address["ip-address"])
                             elif ip_address["ip-address-type"] == "ipv6":
-                                ipv6_address = validate_ipv6(ip_address["ip-address"])
+                                ipv6_address = validate_ip(ip_address["ip-address"])
 
         if not ipv4_address:
             try:

--- a/prometheuspvesd/model.py
+++ b/prometheuspvesd/model.py
@@ -12,8 +12,6 @@ class Host:
         self.vmid = vmid
         self.pve_type = pve_type
         self.labels = {}
-        # kept for backwards compatibility
-        self.labels["__meta_pve_ip"] = ipv4_address
         self.labels["__meta_pve_ipv4"] = ipv4_address
         self.labels["__meta_pve_ipv6"] = ipv6_address
         self.labels["__meta_pve_name"] = hostname

--- a/prometheuspvesd/model.py
+++ b/prometheuspvesd/model.py
@@ -5,19 +5,23 @@
 class Host:
     """Represents a virtual machine or container in PVE."""
 
-    def __init__(self, vmid, hostname, ip_address, pve_type):
+    def __init__(self, vmid, hostname, ipv4_address, ipv6_address, pve_type):
         self.hostname = hostname
-        self.ip_address = ip_address
+        self.ipv4_address = ipv4_address
+        self.ipv6_address = ipv6_address
         self.vmid = vmid
         self.pve_type = pve_type
         self.labels = {}
-        self.labels["__meta_pve_ip"] = ip_address
+        # kept for backwards compatibility
+        self.labels["__meta_pve_ip"] = ipv4_address
+        self.labels["__meta_pve_ipv4"] = ipv4_address
+        self.labels["__meta_pve_ipv6"] = ipv6_address
         self.labels["__meta_pve_name"] = hostname
         self.labels["__meta_pve_type"] = pve_type
         self.labels["__meta_pve_vmid"] = str(vmid)
 
     def __str__(self):
-        return f"{self.hostname}({self.vmid}): {self.pve_type} {self.ip_address}"
+        return f"{self.hostname}({self.vmid}): {self.pve_type} {self.ipv4_address}"
 
     def add_label(self, key, value):
         key = key.replace("-", "_").replace(" ", "_")

--- a/prometheuspvesd/model.py
+++ b/prometheuspvesd/model.py
@@ -21,7 +21,8 @@ class Host:
         self.labels["__meta_pve_vmid"] = str(vmid)
 
     def __str__(self):
-        return f"{self.hostname}({self.vmid}): {self.pve_type} {self.ipv4_address} {self.ipv6_address}"
+        return f"{self.hostname}({self.vmid}): {self.pve_type} \
+                  {self.ipv4_address} {self.ipv6_address}"
 
     def add_label(self, key, value):
         key = key.replace("-", "_").replace(" ", "_")

--- a/prometheuspvesd/model.py
+++ b/prometheuspvesd/model.py
@@ -21,7 +21,7 @@ class Host:
         self.labels["__meta_pve_vmid"] = str(vmid)
 
     def __str__(self):
-        return f"{self.hostname}({self.vmid}): {self.pve_type} {self.ipv4_address}"
+        return f"{self.hostname}({self.vmid}): {self.pve_type} {self.ipv4_address} {self.ipv6_address}"
 
     def add_label(self, key, value):
         key = key.replace("-", "_").replace(" ", "_")


### PR DESCRIPTION
Add `__meta_pve_ipv4` and `__meta_pve_ipv6` labels
Both can be `false` if no matching IP was detected.

For ipv6 not only loopback IP addresses are skipped, but also local link adresses, since prometheus might not be running on the same network as the vms.

Replaces #149 
Fixes #148 