### PR TITLE
Implement exclude_tags

### DIFF
--- a/docs/content/configuration/defaults.md
+++ b/docs/content/configuration/defaults.md
@@ -28,6 +28,9 @@ exclude_state: []
 # needs to be a list of strings
 exclude_vmid: []
 
+# can be used to exclude vms by tags (proxmox 6+)
+exclude_tags: []
+
 pve:
     server:
     user:

--- a/prometheuspvesd/config.py
+++ b/prometheuspvesd/config.py
@@ -94,6 +94,12 @@ class Config():
             "file": True,
             "type": environs.Env().list
         },
+        "exclude_tags": {
+            "default": [],
+            "env": "EXCLUDE_TAGS",
+            "file": True,
+            "type": environs.Env().list
+        },
         "pve.server": {
             "default": "",
             "env": "PVE_SERVER",

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -157,6 +157,11 @@ class Discovery():
             if str(obj["vmid"]) in self.config.config["exclude_vmid"]:
                 continue
 
+            if isinstance(obj["tags"], str) \
+                    and not set(obj["tags"].split(","))\
+                    .isdisjoint(map(str, self.config.config["exclude_tags"])):
+                continue
+
             filtered.append(item.copy())
         return filtered
 

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -157,9 +157,9 @@ class Discovery():
             if str(obj["vmid"]) in self.config.config["exclude_vmid"]:
                 continue
 
-            if isinstance(obj["tags"], str) \
-                    and not set(obj["tags"].split(","))\
-                    .isdisjoint(map(str, self.config.config["exclude_tags"])):
+            if isinstance(obj["tags"], str) and not set(obj["tags"].split(",")).isdisjoint(
+                    self.config.config["exclude_tags"]
+            ):
                 continue
 
             filtered.append(item.copy())

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -157,8 +157,9 @@ class Discovery():
             if str(obj["vmid"]) in self.config.config["exclude_vmid"]:
                 continue
 
-            if isinstance(obj["tags"], str) and not set(obj["tags"].split(",")).isdisjoint(
-                    self.config.config["exclude_tags"]
+            if (
+                isinstance(obj["tags"], str)
+                and not set(obj["tags"].split(",")).isdisjoint(self.config.config["exclude_tags"])
             ):
                 continue
 

--- a/prometheuspvesd/test/fixtures/fixtures.py
+++ b/prometheuspvesd/test/fixtures/fixtures.py
@@ -34,7 +34,8 @@ def qemus():
             "disk": 0,
             "status": "running",
             "netout": 12159205236,
-            "mem": 496179157
+            "mem": 496179157,
+            "tags": "unmonitored,excluded"
         },
         {
             "diskwrite": 0,
@@ -53,6 +54,25 @@ def qemus():
             "status": "running",
             "netout": 12159205236,
             "mem": 496179157
+        },
+        {
+            "diskwrite": 0,
+            "vmid": "102",
+            "name": "102.example.com",
+            "cpu": 0.0202130478509556,
+            "diskread": 0,
+            "template": "",
+            "uptime": 3101505,
+            "maxdisk": 26843545600,
+            "maxmem": 1073741824,
+            "pid": "1765",
+            "cpus": 1,
+            "netin": 2856071643,
+            "disk": 0,
+            "status": "prelaunch",
+            "netout": 12159205236,
+            "mem": 496179157,
+            "tags": "monitored"
         },
     ]
 

--- a/prometheuspvesd/test/unit/test_discovery.py
+++ b/prometheuspvesd/test/unit/test_discovery.py
@@ -17,14 +17,20 @@ def get_mock(*args):
     return False
 
 
-def test_exclude(discovery_fixture, qemus):
-    discovery_fixture.config.config["exclude_vmid"] = ["100", "101"]
+def test_exclude_vmid(discovery_fixture, qemus):
+    discovery_fixture.config.config["exclude_vmid"] = ["100", "101", "102"]
 
     expected = []
     filtered = discovery_fixture._exclude(qemus)
 
     assert filtered == expected
 
+def test_exclude_status(discovery_fixture, qemus):
+    discovery_fixture.config.config["exclude_vmid"] = []
+    discovery_fixture.config.config["exclude_state"] = ["prelaunch"]
+    filtered = discovery_fixture._exclude(qemus)
+
+    assert len(filtered) == 2
 
 def test_validate_ip(discovery_fixture, addresses):
     # IPv4 validation

--- a/prometheuspvesd/test/unit/test_discovery.py
+++ b/prometheuspvesd/test/unit/test_discovery.py
@@ -26,12 +26,14 @@ def test_exclude_vmid(discovery_fixture, qemus):
     assert filtered == expected
     discovery_fixture.config.config["exclude_vmid"] = []
 
+
 def test_exclude_state(discovery_fixture, qemus):
     discovery_fixture.config.config["exclude_state"] = ["prelaunch"]
     filtered = discovery_fixture._exclude(qemus)
 
     assert len(filtered) == 2
     discovery_fixture.config.config["exclude_state"] = []
+
 
 def test_exclude_tags(discovery_fixture, qemus):
     discovery_fixture.config.config["exclude_tags"] = ["unmonitored"]
@@ -40,6 +42,7 @@ def test_exclude_tags(discovery_fixture, qemus):
 
     assert len(filtered) == 2
     discovery_fixture.config.config["exclude_tags"] = []
+
 
 def test_validate_ip(discovery_fixture, addresses):
     # IPv4 validation

--- a/prometheuspvesd/test/unit/test_discovery.py
+++ b/prometheuspvesd/test/unit/test_discovery.py
@@ -24,13 +24,22 @@ def test_exclude_vmid(discovery_fixture, qemus):
     filtered = discovery_fixture._exclude(qemus)
 
     assert filtered == expected
-
-def test_exclude_status(discovery_fixture, qemus):
     discovery_fixture.config.config["exclude_vmid"] = []
+
+def test_exclude_state(discovery_fixture, qemus):
     discovery_fixture.config.config["exclude_state"] = ["prelaunch"]
     filtered = discovery_fixture._exclude(qemus)
 
     assert len(filtered) == 2
+    discovery_fixture.config.config["exclude_state"] = []
+
+def test_exclude_tags(discovery_fixture, qemus):
+    discovery_fixture.config.config["exclude_tags"] = ["unmonitored"]
+
+    filtered = discovery_fixture._exclude(qemus)
+
+    assert len(filtered) == 2
+    discovery_fixture.config.config["exclude_tags"] = []
 
 def test_validate_ip(discovery_fixture, addresses):
     # IPv4 validation


### PR DESCRIPTION
Proxmox 6+ supports tags on VMs, this allows for a neat way to exclude specific vms from prometheus more easily than having to add them to the `exclude_vm` list one by one.

If no tags are set on a VM it's kept in the list.