### PR TITLE
expose proxmox tags

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -14,4 +14,4 @@ Codecov
 IPv4
 IPv6
 Alertmanager
-vm
+VM

--- a/.dictionary
+++ b/.dictionary
@@ -11,3 +11,7 @@ CLI
 JSON
 toc
 Codecov
+IPv4
+IPv6
+Alertmanager
+vm

--- a/docs/content/usage/_index.md
+++ b/docs/content/usage/_index.md
@@ -35,7 +35,7 @@ The following list of meta labels can be used to relabel your scrape results:
 `__meta_pve_status`
 
 `__meta_pve_tags`
-: A comma-separated list of tags, as set on Proxmox. Tags are supported by Proxmox 6+, and the field is missing if not tags are present on a vm.
+: A comma-separated list of tags, as set on Proxmox. Tags are supported by Proxmox 6+, and the field is missing if no tags are present on a VM.
 
 `__meta_pve_groups`
 : Groups will be discovered from the `Notes` field of a host and need to be set as JSON e.g. `{"groups":["group1","group2"]}`

--- a/docs/content/usage/_index.md
+++ b/docs/content/usage/_index.md
@@ -35,7 +35,7 @@ The following list of meta labels can be used to relabel your scrape results:
 `__meta_pve_status`
 
 `__meta_pve_tags`
-: A comma-separated list of tags, as set on proxmox. Tags are supported by Proxmox 6+, and the field is missing if not tags are present on a VM
+: A comma-separated list of tags, as set on Proxmox. Tags are supported by Proxmox 6+, and the field is missing if not tags are present on a vm.
 
 `__meta_pve_groups`
 : Groups will be discovered from the `Notes` field of a host and need to be set as JSON e.g. `{"groups":["group1","group2"]}`
@@ -62,9 +62,9 @@ This example configuration snippet for the Prometheus `scrape_config` Prometheus
     target_label: instance
 ```
 
-### IPv4 or IPv6 usage
+### IPv4 or c usage
 
-Set the address from the ipv4 or ipv6 meta label, and not the name
+Set the address from the IPv4 or IPv4 meta label, and not the name
 
 ```YAML
 relabel_configs:
@@ -76,7 +76,7 @@ relabel_configs:
 
 ## Convert tags to custom labels
 
-Eg. Extract `group` and `alert` from a list of tags like this: `__meta_pve_tags="alert:team-1,group:cluster-1,node:node-1"`
+E.g. Extract `group` and `alert` from a list of tags like this: `__meta_pve_tags="alert:team-1,group:cluster-1,node:node-1"`
 
 ```YAML
 relabel_configs:
@@ -92,7 +92,7 @@ relabel_configs:
   replacement: "${1}"
 ```
 
-Using the `alert` label, you can then for example set an alertmanager route, for this alert
+Using the `alert` label, you can then for example set an Alertmanager route, for this alert
 
 ```YAML
 routes:

--- a/docs/content/usage/_index.md
+++ b/docs/content/usage/_index.md
@@ -34,6 +34,9 @@ The following list of meta labels can be used to relabel your scrape results:
 
 `__meta_pve_status`
 
+`__meta_pve_tags`
+: A comma-separated list of tags, as set on proxmox. Tags are supported by Proxmox 6+, and the field is missing if not tags are present on a VM
+
 `__meta_pve_groups`
 : Groups will be discovered from the `Notes` field of a host and need to be set as JSON e.g. `{"groups":["group1","group2"]}`
 
@@ -57,4 +60,41 @@ This example configuration snippet for the Prometheus `scrape_config` Prometheus
   - source_labels:
     - __meta_pve_name
     target_label: instance
+```
+
+### IPv4 or IPv6 usage
+Set the address from the ipv4 or ipv6 meta label, and not the name
+```YAML
+relabel_configs:
+- replacement: ${1}:9273
+  source_labels:
+  - __meta_pve_ipv4
+  target_label: __address__
+```
+
+## Convert tags to custom labels
+Eg. Extract `group` and `alert` from a list of tags like this: `__meta_pve_tags="alert:team-1,group:cluster-1,node:node-1"`
+```YAML
+relabel_configs:
+- source_labels:
+  - __meta_pve_tags
+  regex: ".*group:([\w\-_]*)"
+  target_label: "group"
+  replacement: "${1}"
+- source_labels:
+  - __meta_pve_tags
+  regex: ".*alert:([\w\-_]*)"
+  target_label: "alert"
+  replacement: "${1}"
+```
+
+Using the `alert` label, you can then for example set an alertmanager route, for this alert
+```YAML
+routes:
+- receiver: "empty"
+  matchers:
+  - alert = muted
+- receiver: "team-1"
+  matchers:
+  - alert = team-1
 ```

--- a/docs/content/usage/_index.md
+++ b/docs/content/usage/_index.md
@@ -63,7 +63,9 @@ This example configuration snippet for the Prometheus `scrape_config` Prometheus
 ```
 
 ### IPv4 or IPv6 usage
+
 Set the address from the ipv4 or ipv6 meta label, and not the name
+
 ```YAML
 relabel_configs:
 - replacement: ${1}:9273
@@ -73,7 +75,9 @@ relabel_configs:
 ```
 
 ## Convert tags to custom labels
+
 Eg. Extract `group` and `alert` from a list of tags like this: `__meta_pve_tags="alert:team-1,group:cluster-1,node:node-1"`
+
 ```YAML
 relabel_configs:
 - source_labels:
@@ -89,6 +93,7 @@ relabel_configs:
 ```
 
 Using the `alert` label, you can then for example set an alertmanager route, for this alert
+
 ```YAML
 routes:
 - receiver: "empty"

--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -229,7 +229,7 @@ class Discovery():
                 prom_host = Host(vmid, host, ipv4_address, ipv6_address, pve_type)
 
                 config_flags = [("cpu", "sockets"), ("cores", "cores"), ("memory", "memory")]
-                meta_flags = [("status", "proxmox_status")]
+                meta_flags = [("status", "proxmox_status"), ("tags", "proxmox_tags")]
 
                 for key, flag in config_flags:
                     if flag in config:


### PR DESCRIPTION
Initial implementation to expose the tags from proxmox to prometheus

The tags are a comma separated list (just as it is exposed by proxmox on the API), and if not present (for proxmox <6, or if none are set) it's not set

WIP because I also want to update the docs to include some examples, how to make proper use of the tags.
I've also tried to implement a test for it outside the model test, but for this to work, quite a lot of the client.get has to be mocked 

I first set it as a attribute on the host model, but I feel that this implementation, is more in line with the rest and doesn't cause an empty label if the tags are not present