### PR TITLE
Allow reading output file by group

### DIFF
--- a/prometheuspvesd/cli.py
+++ b/prometheuspvesd/cli.py
@@ -3,10 +3,10 @@
 
 import argparse
 import json
-from os import chmod
 import shutil
 import signal
 import tempfile
+from os import chmod
 from time import sleep
 
 from prometheus_client import start_http_server

--- a/prometheuspvesd/cli.py
+++ b/prometheuspvesd/cli.py
@@ -3,6 +3,7 @@
 
 import argparse
 import json
+from os import chmod
 import shutil
 import signal
 import tempfile
@@ -170,6 +171,7 @@ class PrometheusSD:
             json.dump(output, tf, indent=4)
 
         shutil.move(temp_file.name, self.config.config["output_file"])
+        chmod(self.config.config["output_file"], 0o640)
 
     def _terminate(self, signal, frame):
         self.log.sysexit_with_message("Terminating", code=0)


### PR DESCRIPTION
When running the pve-sd in a kubernetes cluster without root, the file permissions are too limited.

Opening the file to be read by the group solves this, without influencing the security too much.

A more complete implementation would allow setting the mode from the config file, but this might be overkill