### PR TITLE
Work around interface without IP

### DIFF
--- a/prometheuspvesd/discovery.py
+++ b/prometheuspvesd/discovery.py
@@ -68,7 +68,7 @@ class Discovery():
 
             if type(networks) is list:
                 for network in networks:
-                    for ip_address in network["ip-addresses"]:
+                    for ip_address in network.get("ip-addresses", []):
                         if ip_address["ip-address-type"] == "ipv4" and not ipv4_address:
                             ipv4_address = self._validate_ip(ip_address["ip-address"])
                         elif ip_address["ip-address-type"] == "ipv6" and not ipv6_address:

--- a/prometheuspvesd/test/fixtures/fixtures.py
+++ b/prometheuspvesd/test/fixtures/fixtures.py
@@ -350,6 +350,10 @@ def networks():
                 "tx-packets": 14423878
             }
         },
+        {
+            "hardware-address": "ba:97:85:bd:9a:a5",
+            "name": "eth1"
+        },
     ]
 
 


### PR DESCRIPTION
Hello :)
when deploying in our infrastructure, the app started crashing with 
```
[ERROR] Unknown error: 'ip-addresses'
```

After some digging around, I found the culprit. Some of our VMs have an interface without any IP.

Sadly the code does not expect an interface without IP. 

The `networks` variable value when the exception happened is
```
[{'hardware-address': '00:00:00:00:00:00', 'statistics': {'tx-packets': 152, 'rx-bytes': 10862, 'tx-dropped': 0, 'rx-errs': 0, 'tx-errs': 0, 'rx-dropped': 0, 'tx-bytes': 10862, 'rx-packets': 152}, 'name': 'lo', 'ip-addresses': [{'ip-address': '127.0.0.1', 'ip-address-type': 'ipv4', 'prefix': 8}, {'ip-address': '::1', 'prefix': 128, 'ip-address-type': 'ipv6'}]}, {'ip-addresses': [{'ip-address': '10.100.10.53', 'ip-address-type': 'ipv4', 'prefix': 24}, {'ip-address-type': 'ipv6', 'prefix': 64, 'ip-address': 'fe80::601e:bbff:fe31:f005'}], 'name': 'ens18', 'statistics': {'tx-bytes': 3667102, 'rx-packets': 278803, 'tx-errs': 0, 'rx-dropped': 0, 'tx-dropped': 0, 'rx-errs': 0, 'tx-packets': 30158, 'rx-bytes': 17864007}, 'hardware-address': '62:1e:bb:31:f0:05'}, {'name': 'ens23', 'ip-addresses': [{'ip-address': '10.100.200.53', 'ip-address-type': 'ipv4', 'prefix': 24}, {'ip-address-type': 'ipv6', 'prefix': 64, 'ip-address': 'fe80::803c:5aff:fef8:88c4'}], 'statistics': {'tx-errs': 0, 'rx-dropped': 0, 'tx-bytes': 2056, 'rx-packets': 571, 'tx-packets': 34, 'rx-bytes': 46053, 'tx-dropped': 0, 'rx-errs': 0}, 'hardware-address': '82:3c:5a:f8:88:c4'}, {'ip-addresses': [{'ip-address': '10.103.21.53', 'ip-address-type': 'ipv4', 'prefix': 24}, {'prefix': 64, 'ip-address-type': 'ipv6', 'ip-address': 'fe80::60e7:b1ff:fe79:944d'}], 'name': 'ens1', 'statistics': {'tx-packets': 157, 'rx-bytes': 30726, 'tx-dropped': 0, 'rx-errs': 0, 'tx-errs': 0, 'rx-dropped': 0, 'tx-bytes': 22159, 'rx-packets': 244}, 'hardware-address': '62:e7:b1:79:94:4d'}, {'hardware-address': 'be:90:b2:52:fb:dc', 'name': 'ens30'}, {'hardware-address': '6e:e7:6c:8b:92:ca', 'statistics': {'tx-packets': 1192, 'rx-bytes': 347292, 'tx-dropped': 0, 'rx-errs': 0, 'tx-errs': 0, 'rx-dropped': 0, 'tx-bytes': 190243, 'rx-packets': 3098}, 'name': 'ens19', 'ip-addresses': [{'ip-address-type': 'ipv4', 'prefix': 24, 'ip-address': '10.100.21.53'}, {'ip-address-type': 'ipv6', 'prefix': 64, 'ip-address': 'fe80::6ce7:6cff:fe8b:92ca'}]}, {'ip-addresses': [{'prefix': 24, 'ip-address-type': 'ipv4', 'ip-address': '10.100.22.53'}, {'ip-address': 'fe80::80ca:c8ff:fecf:82d5', 'ip-address-type': 'ipv6', 'prefix': 64}], 'name': 'ens20', 'statistics': {'rx-packets': 870, 'tx-bytes': 141682, 'rx-dropped': 0, 'tx-errs': 0, 'rx-errs': 0, 'tx-dropped': 0, 'rx-bytes': 134508, 'tx-packets': 871}, 'hardware-address': '82:ca:c8:cf:82:d5'}, {'hardware-address': 'ee:e0:71:fb:31:d4', 'statistics': {'tx-packets': 253, 'rx-bytes': 57456694, 'tx-dropped': 0, 'rx-errs': 0, 'tx-errs': 0, 'rx-dropped': 0, 'tx-bytes': 37513, 'rx-packets': 955669}, 'ip-addresses': [{'ip-address': '10.100.12.53', 'prefix': 23, 'ip-address-type': 'ipv4'}, {'ip-address-type': 'ipv6', 'prefix': 64, 'ip-address': 'fe80::ece0:71ff:fefb:31d4'}], 'name': 'ens21'}, {'ip-addresses': [{'ip-address-type': 'ipv4', 'prefix': 23, 'ip-address': '10.100.14.53'}, {'ip-address': 'fe80::fc7a:52ff:fe0f:9cde', 'ip-address-type': 'ipv6', 'prefix': 64}], 'name': 'ens22', 'hardware-address': 'fe:7a:52:0f:9c:de', 'statistics': {'tx-dropped': 0, 'rx-errs': 0, 'tx-packets': 275, 'rx-bytes': 254934, 'tx-bytes': 42479, 'rx-packets': 2188, 'tx-errs': 0, 'rx-dropped': 0}}]
```

and the mailformed `ip_address` variable content:
```
{'hardware-address': 'be:90:b2:52:fb:dc', 'name': 'ens30'}

```

This corresponds to the `ip a` command (output shortened)
```
5: ens30: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether be:90:b2:52:fb:dc brd ff:ff:ff:ff:ff:ff

```
This MR fixes the case when there is no `ip-addresses` key in the `network` dict.