### PR TITLE
feat: support custom proxmox node port via server `host:port`

### DIFF
--- a/docs/content/configuration/defaults.md
+++ b/docs/content/configuration/defaults.md
@@ -37,6 +37,7 @@ include_tags: []
 
 # Set either password or token_name and token_value
 pve:
+    # May include an optional port (`hostname:port`).
     server:
     user:
     password:

--- a/prometheuspvesd/test/unit/test_client.py
+++ b/prometheuspvesd/test/unit/test_client.py
@@ -1,0 +1,54 @@
+"""Test ProxmoxClient class."""
+
+from typing import Any
+
+import pytest
+from proxmoxer.backends.https import Backend
+from pytest_mock import MockerFixture
+
+from prometheuspvesd.client import ProxmoxClient
+from prometheuspvesd.config import Config
+
+pytest_plugins = [
+    "prometheuspvesd.test.fixtures.fixtures",
+]
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        {"pve.password": "dummy", "pve.token_name": "", "pve.token_value": ""},
+        {"pve.password": "", "pve.token_name": "dummy", "pve.token_value": "dummy"},
+    ],
+)
+@pytest.mark.parametrize("server", ["proxmox.example.com", "proxmox.example.com:443", "[::1]:443"])
+def test_auth_forwards_server_unchanged(
+    mocker: MockerFixture, builtins: dict[str, Any], test_input: dict[str, str], server: str
+) -> None:
+    """The server value is forwarded unchanged so proxmoxer can parse an optional `:port`."""
+    for key, value in test_input.items():
+        builtins[key]["default"] = value
+
+    builtins["pve.server"]["default"] = server
+    mocker.patch.dict(Config.SETTINGS, builtins)
+    mock_proxmox = mocker.patch("prometheuspvesd.client.ProxmoxAPI")
+
+    ProxmoxClient()
+
+    assert mock_proxmox.call_args.args[0] == server
+    assert "port" not in mock_proxmox.call_args.kwargs
+
+
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        ("proxmox.example.com", "https://proxmox.example.com:8006/api2/json"),
+        ("proxmox.example.com:443", "https://proxmox.example.com:443/api2/json"),
+        ("[::1]:443", "https://[::1]:443/api2/json"),
+    ],
+)
+def test_proxmoxer_parses_server_port(host: str, expected: str) -> None:
+    """Proxmoxer resolves an optional `:port` in the host and falls back to port 8006."""
+    auth = {"user": "dummy", "token_name": "dummy", "token_value": "dummy"}
+
+    assert Backend(host=host, **auth).base_url == expected


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/prometheus-pve-sd/issues/966

`proxmoxer` already parses `hostname:port` from the host argument and
falls back to `8006` when absent. Document that behavior for `pve.server`
and lock it with tests covering pass-through and port resolution
(including IPv6), so no new config option is needed.